### PR TITLE
add hail pip install

### DIFF
--- a/SV_calling_LR/envs.yaml
+++ b/SV_calling_LR/envs.yaml
@@ -24,3 +24,6 @@ dependencies:
  - survivor=1.0.7
  - svanalyzer=0.36
  - samplot
+ - pip
+ - pip:
+   - hail


### PR DESCRIPTION
we may want to just install hail in a separate environment...  but if not, here's the `pip install` included in the main `cattle_sv` environment.